### PR TITLE
Todo期限設定 & メールアラート機能

### DIFF
--- a/todo-app/app/Console/Commands/SendTodoReminders.php
+++ b/todo-app/app/Console/Commands/SendTodoReminders.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use App\Notifications\TodoDueReminder;
+use Illuminate\Console\Command;
+
+class SendTodoReminders extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'todos:send-reminders';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = '明日が期限のTodoについてユーザーにリマインダーメールを送信';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $this->info('リマインダー送信を開始します...');
+
+        // 明日が期限の未完了Todoを持つユーザーを取得
+        $usersWithDueTodos = User::whereHas('todos', function ($query) {
+            $query->dueTomorrow();
+        })->get();
+
+        $sentCount = 0;
+
+        foreach ($usersWithDueTodos as $user) {
+            $dueTodos = $user->todos()->dueTomorrow()->get();
+
+            if ($dueTodos->isNotEmpty()) {
+                $user->notify(new TodoDueReminder($dueTodos));
+                $sentCount++;
+                $this->line("  → {$user->email} に {$dueTodos->count()} 件のリマインダーを送信");
+            }
+        }
+
+        $this->info("完了: {$sentCount} 人のユーザーにリマインダーを送信しました。");
+
+        return Command::SUCCESS;
+    }
+}

--- a/todo-app/app/Console/Kernel.php
+++ b/todo-app/app/Console/Kernel.php
@@ -12,7 +12,10 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
-        // $schedule->command('inspire')->hourly();
+        // 毎日18時にリマインダーメールを送信
+        $schedule->command('todos:send-reminders')
+                 ->dailyAt('18:00')
+                 ->timezone('Asia/Tokyo');
     }
 
     /**

--- a/todo-app/app/Http/Controllers/TodoController.php
+++ b/todo-app/app/Http/Controllers/TodoController.php
@@ -14,7 +14,11 @@ class TodoController extends Controller
 
     public function index()
     {
-        $todos = auth()->user()->todos()->orderBy('created_at', 'desc')->get();
+        $todos = auth()->user()->todos()
+            ->orderByRaw('CASE WHEN due_date IS NULL THEN 1 ELSE 0 END')
+            ->orderBy('due_date', 'asc')
+            ->orderBy('created_at', 'desc')
+            ->get();
         return view('todos.index', compact('todos'));
     }
 
@@ -22,11 +26,13 @@ class TodoController extends Controller
     {
         $request->validate([
             'title' => 'required|max:255',
+            'due_date' => 'nullable|date|after_or_equal:today',
         ]);
 
         auth()->user()->todos()->create([
             'title' => $request->title,
             'completed' => false,
+            'due_date' => $request->due_date,
         ]);
 
         return redirect()->route('todos.index')->with('success', 'Todoが作成されました！');

--- a/todo-app/app/Http/Controllers/TodoController.php
+++ b/todo-app/app/Http/Controllers/TodoController.php
@@ -15,8 +15,7 @@ class TodoController extends Controller
     public function index()
     {
         $todos = auth()->user()->todos()
-            ->orderByRaw('CASE WHEN due_date IS NULL THEN 1 ELSE 0 END')
-            ->orderBy('due_date', 'asc')
+            ->orderByRaw('due_date IS NULL, due_date ASC')
             ->orderBy('created_at', 'desc')
             ->get();
         return view('todos.index', compact('todos'));

--- a/todo-app/app/Models/Todo.php
+++ b/todo-app/app/Models/Todo.php
@@ -30,4 +30,41 @@ class Todo extends Model
         return $query->where('completed', false)
                      ->whereDate('due_date', now()->addDay()->toDateString());
     }
+
+    /**
+     * 期限のステータスを取得するアクセサ
+     */
+    public function getDueStatusAttribute(): ?string
+    {
+        if (!$this->due_date) {
+            return null;
+        }
+
+        $today = now()->startOfDay();
+
+        if ($this->due_date->lt($today)) {
+            return 'overdue';
+        }
+        if ($this->due_date->eq($today)) {
+            return 'today';
+        }
+        if ($this->due_date->eq($today->copy()->addDay())) {
+            return 'tomorrow';
+        }
+
+        return null;
+    }
+
+    /**
+     * 期限のラベルを取得するアクセサ
+     */
+    public function getDueLabelAttribute(): ?string
+    {
+        return match ($this->due_status) {
+            'overdue' => '期限切れ',
+            'today' => '今日',
+            'tomorrow' => '明日',
+            default => null,
+        };
+    }
 }

--- a/todo-app/app/Models/Todo.php
+++ b/todo-app/app/Models/Todo.php
@@ -10,10 +10,24 @@ class Todo extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['title', 'completed', 'user_id'];
+    protected $fillable = ['title', 'completed', 'user_id', 'due_date'];
+
+    protected $casts = [
+        'completed' => 'boolean',
+        'due_date' => 'date',
+    ];
 
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * 明日が期限の未完了Todoを取得するスコープ
+     */
+    public function scopeDueTomorrow($query)
+    {
+        return $query->where('completed', false)
+                     ->whereDate('due_date', now()->addDay()->toDateString());
     }
 }

--- a/todo-app/app/Notifications/TodoDueReminder.php
+++ b/todo-app/app/Notifications/TodoDueReminder.php
@@ -8,7 +8,7 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Collection;
 
-class TodoDueReminder extends Notification
+class TodoDueReminder extends Notification implements ShouldQueue
 {
     use Queueable;
 
@@ -46,7 +46,7 @@ class TodoDueReminder extends Notification
             $message->line('・ ' . $todo->title);
         }
 
-        $message->action('Todoを確認する', url('/'))
+        $message->action('Todoを確認する', route('todos.index'))
                 ->line('期限内に完了させましょう！');
 
         return $message;

--- a/todo-app/app/Notifications/TodoDueReminder.php
+++ b/todo-app/app/Notifications/TodoDueReminder.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Collection;
+
+class TodoDueReminder extends Notification
+{
+    use Queueable;
+
+    protected Collection $todos;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(Collection $todos)
+    {
+        $this->todos = $todos;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        $message = (new MailMessage)
+            ->subject('【Todoアプリ】明日が期限のタスクがあります')
+            ->greeting($notifiable->name . 'さん')
+            ->line('以下のTodoが明日期限を迎えます：');
+
+        foreach ($this->todos as $todo) {
+            $message->line('・ ' . $todo->title);
+        }
+
+        $message->action('Todoを確認する', url('/'))
+                ->line('期限内に完了させましょう！');
+
+        return $message;
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'todo_ids' => $this->todos->pluck('id')->toArray(),
+        ];
+    }
+}

--- a/todo-app/database/factories/TodoFactory.php
+++ b/todo-app/database/factories/TodoFactory.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Todo>
+ */
+class TodoFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'title' => fake()->sentence(3),
+            'completed' => false,
+            'user_id' => User::factory(),
+            'due_date' => null,
+        ];
+    }
+
+    /**
+     * 完了済み状態
+     */
+    public function completed(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'completed' => true,
+        ]);
+    }
+
+    /**
+     * 明日が期限
+     */
+    public function dueTomorrow(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'due_date' => now()->addDay()->toDateString(),
+        ]);
+    }
+
+    /**
+     * 今日が期限
+     */
+    public function dueToday(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'due_date' => now()->toDateString(),
+        ]);
+    }
+
+    /**
+     * 期限切れ
+     */
+    public function overdue(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'due_date' => now()->subDays(2)->toDateString(),
+        ]);
+    }
+}

--- a/todo-app/database/migrations/2025_12_15_113024_add_due_date_to_todos_table.php
+++ b/todo-app/database/migrations/2025_12_15_113024_add_due_date_to_todos_table.php
@@ -13,6 +13,7 @@ return new class extends Migration
     {
         Schema::table('todos', function (Blueprint $table) {
             $table->date('due_date')->nullable()->after('completed');
+            $table->index('due_date');
         });
     }
 
@@ -22,6 +23,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('todos', function (Blueprint $table) {
+            $table->dropIndex(['due_date']);
             $table->dropColumn('due_date');
         });
     }

--- a/todo-app/database/migrations/2025_12_15_113024_add_due_date_to_todos_table.php
+++ b/todo-app/database/migrations/2025_12_15_113024_add_due_date_to_todos_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('todos', function (Blueprint $table) {
+            $table->date('due_date')->nullable()->after('completed');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('todos', function (Blueprint $table) {
+            $table->dropColumn('due_date');
+        });
+    }
+};

--- a/todo-app/resources/views/todos/index.blade.php
+++ b/todo-app/resources/views/todos/index.blade.php
@@ -99,6 +99,47 @@
             background: #c82333;
         }
 
+        input[type="date"] {
+            padding: 12px 16px;
+            border: 2px solid #e0e0e0;
+            border-radius: 8px;
+            font-size: 16px;
+            transition: border-color 0.3s;
+            min-width: 150px;
+        }
+
+        input[type="date"]:focus {
+            outline: none;
+            border-color: #667eea;
+        }
+
+        .due-date {
+            font-size: 12px;
+            color: #666;
+            margin-left: 10px;
+        }
+
+        .due-date.overdue {
+            color: #dc3545;
+            font-weight: 600;
+        }
+
+        .due-date.today {
+            color: #fd7e14;
+            font-weight: 600;
+        }
+
+        .due-date.tomorrow {
+            color: #ffc107;
+            font-weight: 600;
+        }
+
+        .error-message {
+            color: #dc3545;
+            font-size: 14px;
+            margin-top: 5px;
+        }
+
         .todo-list {
             list-style: none;
         }
@@ -240,8 +281,16 @@
                         required
                         autofocus
                     >
+                    <input
+                        type="date"
+                        name="due_date"
+                        min="{{ date('Y-m-d') }}"
+                    >
                     <button type="submit" class="btn btn-primary">追加</button>
                 </div>
+                @error('due_date')
+                    <p class="error-message">{{ $message }}</p>
+                @enderror
             </form>
 
             @if($todos->count() > 0)
@@ -258,6 +307,26 @@
                                 >
                                 <span class="todo-title {{ $todo->completed ? 'completed' : '' }}">
                                     {{ $todo->title }}
+                                    @if($todo->due_date)
+                                        @php
+                                            $dueDate = $todo->due_date;
+                                            $today = now()->startOfDay();
+                                            $class = '';
+                                            if ($dueDate->lt($today)) {
+                                                $class = 'overdue';
+                                            } elseif ($dueDate->eq($today)) {
+                                                $class = 'today';
+                                            } elseif ($dueDate->eq($today->copy()->addDay())) {
+                                                $class = 'tomorrow';
+                                            }
+                                        @endphp
+                                        <span class="due-date {{ $class }}">
+                                            {{ $dueDate->format('Y/m/d') }}
+                                            @if($class === 'overdue')（期限切れ）@endif
+                                            @if($class === 'today')（今日）@endif
+                                            @if($class === 'tomorrow')（明日）@endif
+                                        </span>
+                                    @endif
                                 </span>
                             </form>
 

--- a/todo-app/resources/views/todos/index.blade.php
+++ b/todo-app/resources/views/todos/index.blade.php
@@ -308,23 +308,9 @@
                                 <span class="todo-title {{ $todo->completed ? 'completed' : '' }}">
                                     {{ $todo->title }}
                                     @if($todo->due_date)
-                                        @php
-                                            $dueDate = $todo->due_date;
-                                            $today = now()->startOfDay();
-                                            $class = '';
-                                            if ($dueDate->lt($today)) {
-                                                $class = 'overdue';
-                                            } elseif ($dueDate->eq($today)) {
-                                                $class = 'today';
-                                            } elseif ($dueDate->eq($today->copy()->addDay())) {
-                                                $class = 'tomorrow';
-                                            }
-                                        @endphp
-                                        <span class="due-date {{ $class }}">
-                                            {{ $dueDate->format('Y/m/d') }}
-                                            @if($class === 'overdue')（期限切れ）@endif
-                                            @if($class === 'today')（今日）@endif
-                                            @if($class === 'tomorrow')（明日）@endif
+                                        <span class="due-date {{ $todo->due_status }}">
+                                            {{ $todo->due_date->format('Y/m/d') }}
+                                            @if($todo->due_label)（{{ $todo->due_label }}）@endif
                                         </span>
                                     @endif
                                 </span>

--- a/todo-app/tests/Feature/SendTodoRemindersTest.php
+++ b/todo-app/tests/Feature/SendTodoRemindersTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Todo;
+use App\Models\User;
+use App\Notifications\TodoDueReminder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class SendTodoRemindersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_reminder_is_sent_to_users_with_due_tomorrow_todos(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+        Todo::factory()->dueTomorrow()->create(['user_id' => $user->id]);
+
+        $this->artisan('todos:send-reminders')
+             ->expectsOutput('リマインダー送信を開始します...')
+             ->assertSuccessful();
+
+        Notification::assertSentTo($user, TodoDueReminder::class);
+    }
+
+    public function test_reminder_is_not_sent_when_no_todos_due_tomorrow(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+        // 今日期限のTodo（明日ではない）
+        Todo::factory()->dueToday()->create(['user_id' => $user->id]);
+
+        $this->artisan('todos:send-reminders')->assertSuccessful();
+
+        Notification::assertNothingSent();
+    }
+
+    public function test_reminder_is_not_sent_for_completed_todos(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+        // 明日期限だが完了済み
+        Todo::factory()->dueTomorrow()->completed()->create(['user_id' => $user->id]);
+
+        $this->artisan('todos:send-reminders')->assertSuccessful();
+
+        Notification::assertNothingSent();
+    }
+
+    public function test_reminder_includes_multiple_todos(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+        Todo::factory()->dueTomorrow()->count(3)->create(['user_id' => $user->id]);
+
+        $this->artisan('todos:send-reminders')->assertSuccessful();
+
+        Notification::assertSentTo($user, TodoDueReminder::class, function ($notification) {
+            $array = $notification->toArray(new User());
+            return count($array['todo_ids']) === 3;
+        });
+    }
+
+    public function test_multiple_users_receive_their_own_reminders(): void
+    {
+        Notification::fake();
+
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+
+        Todo::factory()->dueTomorrow()->create(['user_id' => $user1->id]);
+        Todo::factory()->dueTomorrow()->count(2)->create(['user_id' => $user2->id]);
+
+        $this->artisan('todos:send-reminders')->assertSuccessful();
+
+        Notification::assertSentTo($user1, TodoDueReminder::class);
+        Notification::assertSentTo($user2, TodoDueReminder::class);
+    }
+}

--- a/todo-app/tests/Feature/TodoDueDateTest.php
+++ b/todo-app/tests/Feature/TodoDueDateTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Todo;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TodoDueDateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_create_todo_with_due_date(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('/todos', [
+            'title' => 'テストTodo',
+            'due_date' => now()->addDays(3)->toDateString(),
+        ]);
+
+        $response->assertRedirect('/');
+        $this->assertDatabaseHas('todos', [
+            'title' => 'テストTodo',
+            'user_id' => $user->id,
+        ]);
+
+        $todo = Todo::where('title', 'テストTodo')->first();
+        $this->assertEquals(now()->addDays(3)->toDateString(), $todo->due_date->toDateString());
+    }
+
+    public function test_user_can_create_todo_without_due_date(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('/todos', [
+            'title' => '期限なしTodo',
+        ]);
+
+        $response->assertRedirect('/');
+        $this->assertDatabaseHas('todos', [
+            'title' => '期限なしTodo',
+            'due_date' => null,
+        ]);
+    }
+
+    public function test_due_date_cannot_be_in_past(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('/todos', [
+            'title' => '過去日Todo',
+            'due_date' => now()->subDay()->toDateString(),
+        ]);
+
+        $response->assertSessionHasErrors('due_date');
+    }
+
+    public function test_due_tomorrow_scope_returns_correct_todos(): void
+    {
+        $user = User::factory()->create();
+
+        // 明日期限の未完了Todo（対象）
+        $dueTomorrow = Todo::factory()->dueTomorrow()->create(['user_id' => $user->id]);
+
+        // 今日期限（対象外）
+        Todo::factory()->dueToday()->create(['user_id' => $user->id]);
+
+        // 明日期限だが完了済み（対象外）
+        Todo::factory()->dueTomorrow()->completed()->create(['user_id' => $user->id]);
+
+        // 期限なし（対象外）
+        Todo::factory()->create(['user_id' => $user->id]);
+
+        $result = Todo::dueTomorrow()->get();
+
+        $this->assertCount(1, $result);
+        $this->assertEquals($dueTomorrow->id, $result->first()->id);
+    }
+
+    public function test_todos_are_sorted_by_due_date(): void
+    {
+        $user = User::factory()->create();
+
+        // 期限なし
+        $noDate = Todo::factory()->create(['user_id' => $user->id, 'title' => '期限なし']);
+
+        // 3日後
+        $threeDays = Todo::factory()->create([
+            'user_id' => $user->id,
+            'title' => '3日後',
+            'due_date' => now()->addDays(3)->toDateString(),
+        ]);
+
+        // 明日
+        $tomorrow = Todo::factory()->dueTomorrow()->create(['user_id' => $user->id, 'title' => '明日']);
+
+        $response = $this->actingAs($user)->get('/');
+
+        $response->assertStatus(200);
+        $response->assertSeeInOrder(['明日', '3日後', '期限なし']);
+    }
+}


### PR DESCRIPTION
## Summary
- Todoに期限日（due_date）を任意で設定可能に
- 毎日18時に「明日期限」のTodoをメール通知する機能を追加
- 期限順でTodoをソート（期限あり優先→期限日昇順）
- 期限切れ/今日/明日を色分け表示

## 変更ファイル
- `database/migrations/*_add_due_date_to_todos_table.php` - due_dateカラム追加
- `app/Models/Todo.php` - fillable, casts, scopeDueTomorrow()
- `app/Http/Controllers/TodoController.php` - バリデーション、ソート
- `resources/views/todos/index.blade.php` - 日付入力、期限表示
- `app/Notifications/TodoDueReminder.php` - メール通知クラス
- `app/Console/Commands/SendTodoReminders.php` - リマインダーコマンド
- `app/Console/Kernel.php` - スケジューラー設定（毎日18時）
- `database/factories/TodoFactory.php` - テスト用Factory
- `tests/Feature/TodoDueDateTest.php` - 期限機能テスト
- `tests/Feature/SendTodoRemindersTest.php` - リマインダーテスト

## Test plan
- [x] 期限付きTodo作成テスト
- [x] 期限なしTodo作成テスト
- [x] 過去日バリデーションテスト
- [x] scopeDueTomorrow()テスト
- [x] ソート順テスト
- [x] リマインダー送信テスト（対象あり/なし/完了済み）

Closes #1, #2, #3, #4, #5, #6, #7, #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)